### PR TITLE
Fixed project path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-gromitai
+gromit

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Amir & Masih
+Copyright (c) 2025 GromitAI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Amir
+Copyright (c) 2025 Amir & Masih
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/amirhd23/gromitai
+module github.com/gromitai/gromit
 
 go 1.24.5
 


### PR DESCRIPTION
Fixed project path from `github.com/amirhd23/gromitai` to `github.com/gromitai/gromit`.
Updated license for the copyright.
Updated .gitignore for the new executable file.


Fixes #10 